### PR TITLE
🐛 Fix critical bug making serialization broken, other fixes

### DIFF
--- a/Personnel/src/serialisation/Serialization.java
+++ b/Personnel/src/serialisation/Serialization.java
@@ -13,31 +13,18 @@ import personnel.SauvegardeImpossible;
 public class Serialization implements personnel.Passerelle
 {
 	private static final String FILE_NAME = "GestionPersonnel.srz";
-	GestionPersonnel gestionPersonnel;
-		
+
 	@Override
 	public GestionPersonnel getGestionPersonnel()
 	{
-		ObjectInputStream ois = null;
-		try
+		try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(FILE_NAME)))
 		{
-			FileInputStream fis = new FileInputStream(FILE_NAME);
-			ois = new ObjectInputStream(fis);
-			return (GestionPersonnel)(ois.readObject());
+			return (GestionPersonnel) ois.readObject();
 		}
 		catch (IOException | ClassNotFoundException e)
 		{
 			return null;
 		}
-		finally
-		{
-				try
-				{
-					if (ois != null)
-						ois.close();
-				} 
-				catch (IOException e){}
-		}	
 	}
 	
 	/**
@@ -45,29 +32,16 @@ public class Serialization implements personnel.Passerelle
 	 * lors d'une exécution ultérieure du programme.
 	 * @throws SauvegardeImpossible Si le support de sauvegarde est inaccessible.
 	 */
-	
 	@Override
 	public void sauvegarderGestionPersonnel(GestionPersonnel gestionPersonnel) throws SauvegardeImpossible
 	{
-		ObjectOutputStream oos = null;
-		try
+		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(FILE_NAME)))
 		{
-			FileOutputStream fis = new FileOutputStream(FILE_NAME);
-			oos = new ObjectOutputStream(fis);
-			oos.writeObject(this);
+			oos.writeObject(gestionPersonnel);
 		}
 		catch (IOException e)
 		{
 			throw new SauvegardeImpossible(e);
-		}
-		finally
-		{
-			try
-			{
-				if (oos != null)
-					oos.close();
-			} 
-			catch (IOException e){}
 		}
 	}
 	


### PR DESCRIPTION
- Remove useless gestionPersonnel member variable
- Fix possible memory leaks and reduce code by making use of try-with-resources instead of try catch finally
- Fix critical bug : Serialization class was trying to serialize itself instead of serializing gestionPersonnel parameter
As long as Serialization class is not serializable, it was raising an exception (even if it was serializable it was not the great thing to serialize so it'll have crashed when trying to deserialize Serialization class into GestionPersonnel class)